### PR TITLE
Revert 'Add ItemGroup to mixin template.'

### DIFF
--- a/Source/ScriptTemplates/content/2_Mixin/MixinProject.projitems
+++ b/Source/ScriptTemplates/content/2_Mixin/MixinProject.projitems
@@ -5,7 +5,4 @@
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>8a3cdcc5-4b55-4d87-a415-698a0e1ff06f</SharedGUID>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)/**/*.cs" Visible=" '$(ShowCommonFiles)' == 'true' " />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
After working with VSCode more, I've discovered the problem this was solving was user error. The Solution Explorer adds files to projitems correctly in VSCode once the shared project is in the solution file.

(The problem, in case you're curious, is that VSCode doesn't have UI to add shared projects to your solution, but adding it manually causes everything to behave itself.)

Deeply sorry for the noise/churn. Thanks for making this toolkit!