### PR TITLE
fix(ci): stop re-releasing a Hub version that is already published

### DIFF
--- a/.github/workflows/buildwithartefacts.yml
+++ b/.github/workflows/buildwithartefacts.yml
@@ -461,7 +461,27 @@ jobs:
           name: mdk-hub-linux-installer
           path: ./releases
       
+      # This workflow runs whenever any PackageVersion.txt changes, not only the Hub's, so it reaches this point on
+      # pushes that leave the Hub untouched. Releasing again would overwrite the assets and notes of an already
+      # published release with a rebuild of the same version - which is what happened to hub-v2.2.7 on 24 July, two
+      # months after it went out. The NuGet step is protected from the same thing by --skip-duplicate.
+      - name: Check whether this Hub version is already released
+        id: existing-release
+        run: |
+          if gh release view "hub-v$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "hub-v$VERSION already exists; skipping the release so it is not overwritten."
+            echo "Bump Source/Mdk.Hub/PackageVersion.txt to publish a new Hub release."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "hub-v$VERSION does not exist yet; it will be created."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub Release
+        # A manual run with deployRelease=y is taken as "I meant it", so a botched upload can still be redone.
+        if: steps.existing-release.outputs.exists != 'true' || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: hub-v${{ env.VERSION }}


### PR DESCRIPTION
The build workflow triggers whenever any `PackageVersion.txt` changes, but every deploy job then runs regardless of which package actually moved. `deploy-hub` creates a release for whatever version `Source/Mdk.Hub/PackageVersion.txt` holds, and `softprops/action-gh-release` updates an existing release in place rather than declining — so a push that bumps some other package silently replaces the assets and notes of a Hub release that went out long ago.

Not hypothetical: `hub-v2.2.7` was published on 20 May and had every one of its assets re-uploaded on 24 July, by the main push that bumped `Mdk.CommandLine` for the modifier-stripping change.

The release step now skips when the tag already exists. A manual run with `deployRelease=y` still goes through, so a failed upload can be redone.

The NuGet deploy has always been protected from the same thing by `--skip-duplicate`; this gives the Hub release the equivalent guard.

Touches only `.github/workflows/`, and the push trigger is filtered to `Source/**/PackageVersion.txt`, so merging this publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)