### PR TITLE
fix(extractor): skip hidden blocks and mark fetchable interfaces

### DIFF
--- a/Source/Mdk.Extractor/ExtractorPlugin.cs
+++ b/Source/Mdk.Extractor/ExtractorPlugin.cs
@@ -226,6 +226,13 @@ public class ExtractorPlugin : IPlugin
             {
                 if (definition is not MyCubeBlockDefinition cbd)
                     continue;
+
+                // Blocks the game hides from the build menu. Debug spheres are the obvious case, but this also
+                // keeps the sampled subtype of a mixed type honest: most wheel definitions are hidden, and
+                // documenting a block from one of those would describe something nobody can place.
+                if (!cbd.Public)
+                    continue;
+
                 if (byTypeId.TryGetValue(cbd.Id.TypeId, out var existing) && existing.CubeSize == MyCubeSize.Large)
                     continue;
                 byTypeId[cbd.Id.TypeId] = cbd;
@@ -381,6 +388,13 @@ public class BlockInfo(
     List<ITerminalProperty> properties)
 {
     /// <summary>
+    ///     Whether an interface descends from this is what tells a consumer it can fetch a block through it.
+    ///     Recorded here rather than left to be worked out later, because this is the only place the actual
+    ///     type hierarchy is available.
+    /// </summary>
+    static readonly Type TerminalBlockInterface = typeof(Sandbox.ModAPI.Ingame.IMyTerminalBlock);
+
+    /// <summary>
     ///     The block's object builder type without its prefix, and the key a block is listed under.
     /// </summary>
     public string TypeDefinition { get; } = typeDefinition;
@@ -413,7 +427,9 @@ public class BlockInfo(
             new XAttribute("type", DeclaredInterfaceType?.FullName ?? ""));
 
         foreach (var ingameInterface in IngameInterfaces)
-            root.Add(new XElement("interface", new XAttribute("name", ingameInterface.FullName ?? "")));
+            root.Add(new XElement("interface",
+                new XAttribute("name", ingameInterface.FullName ?? ""),
+                new XAttribute("terminal", TerminalBlockInterface.IsAssignableFrom(ingameInterface) ? "true" : "false")));
         foreach (var action in Actions)
             root.Add(new XElement("action", new XAttribute("name", action.Id), new XAttribute("text", action.Name)));
         foreach (var property in Properties)


### PR DESCRIPTION
Removing the `MyTerminalInterfaceAttribute` filter recovered twelve blocks, but three of them were debug spheres that no player can place. It also left every block listing nine interfaces, most of which are no use for finding it.

- Skip definitions the game marks non-public. Drops `DebugSphere1/2/3` and the legacy `PistonBase`; `IMyPistonBase` remains documented via `ExtendedPistonBase`
- Also stops a hidden subtype being sampled for a type that has both. 32 of 48 wheel definitions are hidden
- Mark each `<interface>` with `terminal="true|false"`, meaning it descends from `IMyTerminalBlock`, so consumers can tell a fetchable interface from a cross-cutting one like `IMyCubeBlock` or `IMyInventoryOwner`

Verified against a live extraction: 89 blocks down to 85, with exactly the four expected removals and nothing else. Interface marking splits 288 fetchable against 361 not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
